### PR TITLE
Fix devantech_usb_xfer return code

### DIFF
--- a/i2c-devantech-iss.c
+++ b/i2c-devantech-iss.c
@@ -305,7 +305,7 @@ static int devantech_usb_xfer(struct i2c_adapter *adapter, struct i2c_msg *msgs,
 		for (i = 0; i < len; i++)
 			pmsg->buf[i] = dev->buffer[i + 2];
 	}
-	ret = 0;
+	ret = num;
 error:
 	return ret;
 }


### PR DESCRIPTION
According to the Linux kernel i2c driver (see i2c-core.c, __i2c_transfer, from where it is called), the master_xfer function should return the number of messages executed if successful.
Hence this small patch.
